### PR TITLE
Remove reference to header file `liblte_rrc.h` that was removed upstream

### DIFF
--- a/srsue/src/upper/rrc.cc
+++ b/srsue/src/upper/rrc.cc
@@ -29,7 +29,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
-#include <srslte/asn1/liblte_rrc.h>
 #include "srsue/hdr/upper/rrc.h"
 #include "srslte/asn1/rrc_asn1.h"
 #include "srslte/common/bcd_helpers.h"


### PR DESCRIPTION
This will fix build error.

This should not bring any effect during execution, but I'm not fully sure. As far as I checked, all the references to the old lib were removed.