### PR TITLE
Quick fix for build on ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ macro(ADD_CXX_COMPILER_FLAG_IF_AVAILABLE flag have)
 endmacro(ADD_CXX_COMPILER_FLAG_IF_AVAILABLE)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-comment -Wno-reorder -Wno-unused-but-set-variable -Wno-unused-variable -Wformat -Wmissing-field-initializers -Wtype-limits -std=c++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-comment -Wno-reorder -Wno-unused-but-set-variable -Wno-unused-variable -Wformat -Wmissing-field-initializers -Wtype-limits")
 
   find_package(SSE)
   if (HAVE_AVX2)


### PR DESCRIPTION
This fixes the issue referenced here (https://github.com/EFForg/crocodilehunter/issues/84#issuecomment-670807945), where the build for srsUE fails in ubuntu 20.04 due to the following error:

srsLTE/srsue/src/phy/phch_worker.cc:1599:31: error: ‘cabsf’ was not declared in this scope; did you mean ‘fabsf’?

The fix is simply to remove the C++ compiler flag "-std=c++11". I will be the first to admit it would be better to address the root problem, but also it works.

