### PR TITLE
Cell measurement hang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ macro(ADD_CXX_COMPILER_FLAG_IF_AVAILABLE flag have)
 endmacro(ADD_CXX_COMPILER_FLAG_IF_AVAILABLE)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-comment -Wno-reorder -Wno-unused-but-set-variable -Wno-unused-variable -Wformat -Wmissing-field-initializers -Wtype-limits -std=c++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-comment -Wno-reorder -Wno-unused-but-set-variable -Wno-unused-variable -Wformat -Wmissing-field-initializers -Wtype-limits")
 
   find_package(SSE)
   if (HAVE_AVX2)

--- a/lib/examples/cell_measurement.cc
+++ b/lib/examples/cell_measurement.cc
@@ -395,6 +395,7 @@ int main(int argc, char **argv) {
   /* begin cell search loop */
   freq = -1;
   while (! go_exit) {
+    srslte_rf_stop_rx_stream(&rf);
     bool acks[SRSLTE_MAX_CODEWORDS] = {false};
     /* set rf_freq */
     freq++;
@@ -421,6 +422,8 @@ int main(int argc, char **argv) {
     srslte_rf_start_rx_stream(&rf, false);
 
     n = srslte_ue_cellsearch_scan(&cs, found_cells, NULL);
+    srslte_rf_stop_rx_stream(&rf);
+
     int ret = SRSLTE_UE_MIB_NOTFOUND;
     srslte_cell_t cell;
     if (n < 0) {
@@ -497,12 +500,10 @@ int main(int argc, char **argv) {
           continue;
         }
 
-	/*
       printf("Stopping RF and flushing buffer...\n");
       srslte_rf_stop_rx_stream(&rf);
       srslte_rf_flush_buffer(&rf);
       printf("DONE Stopping RF and flushing buffer...\n");
-      */
 
 	    fprintf(stderr, "******* init multi\n");
       if (srslte_ue_sync_init_multi(&ue_sync, cell.nof_prb, cell.id==1000, srslte_rf_recv_wrapper, 1, (void*) &rf)) {
@@ -763,6 +764,3 @@ int main(int argc, char **argv) {
   printf("\nBye\n");
   exit(0);
 }
-
-
-


### PR DESCRIPTION
I was having a problem where cell_measurement would hang intermittently . I'm using a bladerf 2 xa4 on ubuntu 20.04.

What I found is that calling srslte_rf_start_rx_stream() when the stream has already started was causing the problem. This fix inserts a few srslte_rf_stop_rx_stream(), which fixes it.